### PR TITLE
Fix privacy page path and heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
   <li>No backend server, no advertising SDKs, no analytics SDKs.</li>
 </ul>
 
-<h2>3. Device Permissions</h2>
+<h2>3. Device Permission</h2>
 <table>
   <tr><th>Permission</th><th>Purpose</th><th>Prompt timing</th></tr>
   <tr><td>RECORD_AUDIO / Microphone</td><td>Capture freestyle vocals &amp; drum pads</td><td>First tap on “Record”</td></tr>


### PR DESCRIPTION
## Summary
- rename `privacy_en.html` to `index.html` for GitHub Pages
- change "Device Permissions" heading to singular

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68601f439254832a9c924363a5ed473f